### PR TITLE
add gnu89 to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ spice.o: spice.f
 	$(FC) -c $(FFLAGS) spice.f -o spice.o 
 
 unix.o: unix.c
-	$(CC) $(CFLAGS) -c unix.c -o unix.o
+	$(CC) $(CFLAGS) -std=gnu89 -c unix.c -o unix.o
 
 clean:
 	rm -f $(OBJS) spice


### PR DESCRIPTION
unix.c is failing to compile on fedora 43, It is using gcc version below.
gcc version 15.2.1 20260123 (Red Hat 15.2.1-7) (GCC)

